### PR TITLE
Additional visca commands

### DIFF
--- a/jr_visca.c
+++ b/jr_visca.c
@@ -70,8 +70,9 @@ int jr_viscaDataToFrame(uint8_t *data, int dataLength, jr_viscaFrame *frame) {
     }
 
     // First byte is header containing sender and receiver addresses.
+    // Except for Address Set (aka Camera Number) and IFClear(Broadcast), which are 0x88, but they don't apply to visca over IP.
     frame->sender = (data[0] >> 4) & 0x7;
-    frame->receiver = data[0] & 0x7;
+    frame->receiver = data[0] & 0xF;
 
     // N bytes of packet data between header byte and 0xff terminator.
     memcpy(frame->data, data + 1, terminatorIndex - 1);
@@ -86,7 +87,7 @@ int jr_viscaFrameToData(uint8_t *data, int dataLength, jr_viscaFrame frame) {
         return -1;
     }
 
-    if ((frame.sender > 7) || (frame.receiver > 7)) {
+    if ((frame.sender > 7) || (frame.receiver > 0xF)) {
         return -1;
     }
 
@@ -140,6 +141,25 @@ void jr_visca_handlePanTiltPositionInqResponseParameters(jr_viscaFrame* frame, u
     }
 }
 
+// AbsolutePosition [81] 01 06 02 [3]VV [4]WW [5]0Y 0Y 0Y 0Y [9]0Z 0Z 0Z 0Z FF
+// VV: Pan speed 0x01 (low speed) to 0x18 (high speed)
+// WW: Tilt speed 0x01 (low speed) to 0x14 (high speed)
+// YYYY: Pan Position
+// ZZZZ: Tilt Position
+void jr_visca_handleAbsolutePanTiltPositionParameters(jr_viscaFrame* frame, union jr_viscaMessageParameters *messageParameters, bool isDecodingFrame) {
+    if (isDecodingFrame) {
+        messageParameters->absolutePanTiltPositionParameters.panSpeed = frame->data[3] & 0xf;
+        messageParameters->absolutePanTiltPositionParameters.tiltSpeed = frame->data[4] & 0xf;
+        messageParameters->absolutePanTiltPositionParameters.panPosition = _jr_viscaRead16FromBuffer(frame->data + 5);
+        messageParameters->absolutePanTiltPositionParameters.tiltPosition = _jr_viscaRead16FromBuffer(frame->data + 9);
+    } else {
+        frame->data[3] = messageParameters->absolutePanTiltPositionParameters.panSpeed;
+        frame->data[4] = messageParameters->absolutePanTiltPositionParameters.tiltSpeed;
+        _jr_viscaWrite16ToBuffer(messageParameters->absolutePanTiltPositionParameters.panPosition, frame->data + 5);
+        _jr_viscaWrite16ToBuffer(messageParameters->absolutePanTiltPositionParameters.tiltPosition, frame->data + 9);
+    }
+}
+
 void jr_visca_handleZoomPositionInqResponseParameters(jr_viscaFrame* frame, union jr_viscaMessageParameters *messageParameters, bool isDecodingFrame) {
     if (isDecodingFrame) {
         messageParameters->zoomPositionParameters.zoomPosition = _jr_viscaRead16FromBuffer(frame->data + 1);
@@ -156,11 +176,39 @@ void jr_visca_handleAckCompletionParameters(jr_viscaFrame* frame, union jr_visca
     }
 }
 
+void jr_visca_handleCameraNumberParameters(jr_viscaFrame* frame, union jr_viscaMessageParameters *messageParameters, bool isDecodingFrame) {
+    // Request: 88 30 01 FF, reply: 88 30 0w FF, w is 2-8 (camera+1)
+    if (isDecodingFrame) {
+        messageParameters->cameraNumberParameters.cameraNum = frame->data[1] & 0xf;
+    } else {
+        frame->data[1] += messageParameters->cameraNumberParameters.cameraNum;
+    }
+}
+
 void jr_visca_handleZoomVariableParameters(jr_viscaFrame* frame, union jr_viscaMessageParameters *messageParameters, bool isDecodingFrame) {
     if (isDecodingFrame) {
         messageParameters->zoomVariableParameters.zoomSpeed = frame->data[3] & 0xf;
     } else {
         frame->data[3] += messageParameters->zoomVariableParameters.zoomSpeed;
+    }
+}
+
+void jr_visca_handlePresetSpeedParameters(jr_viscaFrame* frame, union jr_viscaMessageParameters *messageParameters, bool isDecodingFrame) {
+    if (isDecodingFrame) {
+        uint8_t speed = frame->data[3] & 0xff;
+        speed = (speed < 1) ? 1 : ((speed > 0x18) ? 0x18 : speed);
+        messageParameters->presetSpeedParameters.presetSpeed = speed;
+    } else {
+        frame->data[3] = messageParameters->presetSpeedParameters.presetSpeed;
+    }
+}
+
+void jr_visca_handleMemoryParameters(jr_viscaFrame* frame, union jr_viscaMessageParameters *messageParameters, bool isDecodingFrame) {
+    if (isDecodingFrame) {
+        messageParameters->memoryParameters.memory = frame->data[4] & 0xff;
+        messageParameters->memoryParameters.mode = frame->data[3] & 0xff;
+    } else {
+        frame->data[4] = messageParameters->memoryParameters.memory;
     }
 }
 
@@ -295,6 +343,69 @@ jr_viscaMessageDefinition definitions[] = {
         JR_VISCA_MESSAGE_PAN_TILT_DRIVE,
         &jr_visca_handlePanTiltDriveParameters
     },
+    {
+        {0x30, 0x01},
+        {0xff, 0xff},
+        2,
+        JR_VISCA_MESSAGE_CAMERA_NUMBER,
+        &jr_visca_handleCameraNumberParameters
+    },
+    {
+        {0x01, 0x04, 0x3f, 0x00, 0x00},
+        {0xff, 0xff, 0xff, 0x00, 0x00},
+        5,
+        JR_VISCA_MESSAGE_MEMORY,
+        &jr_visca_handleMemoryParameters
+    },
+    {
+        {0x01, 0x00, 0x01},
+        {0xff, 0xff, 0xff},
+        3,
+        JR_VISCA_MESSAGE_CLEAR,
+        NULL
+    },
+    {   // 01 06 01 pp
+        {0x01, 0x06, 0x01, 0x00},
+        {0xff, 0xff, 0xff, 0x00},
+        4,
+        JR_VISCA_MESSAGE_PRESET_RECALL_SPEED,
+        &jr_visca_handlePresetSpeedParameters
+    },
+    {   // 01 06 02        VV    WW     0Y 0Y 0Y 0Y              0Z 0Z 0Z 0Z
+        {0x01, 0x06, 0x02, 0x00, 0x00,  0x00, 0x00, 0x00, 0x00,  0x00, 0x00, 0x00, 0x00},
+        {0xff, 0xff, 0xff, 0x00, 0x00,  0xf0, 0xf0, 0xf0, 0xf0,  0xf0, 0xf0, 0xf0, 0xf0},
+        13,
+        JR_VISCA_MESSAGE_ABSOLUTE_PAN_TILT,
+        &jr_visca_handleAbsolutePanTiltPositionParameters
+    },
+    {   // Home 81 01 06 04 FF
+        {0x01, 0x06, 0x04},
+        {0xff, 0xff, 0xff},
+        3,
+        JR_VISCA_MESSAGE_HOME,
+        NULL
+    },
+    {   // Reset 81 01 06 05 FF
+        {0x01, 0x06, 0x05},
+        {0xff, 0xff, 0xff},
+        3,
+        JR_VISCA_MESSAGE_RESET,
+        NULL
+    },
+    {   // Cancel 81 2z FF - supported by some cameras but apparently not PTZOptics, which returns syntax error instead of cancel reply. But it does interrupt the current operation.
+        {0x20},
+        {0xf0},
+        1,
+        JR_VISCA_MESSAGE_CANCEL,
+        NULL
+    },
+    {
+        {0x60, 0x04},
+        {0xf0, 0xff},
+        2,
+        JR_VISCA_MESSAGE_CANCEL_REPLY,
+        &jr_visca_handleAckCompletionParameters
+    },
     { {}, {}, 0, 0, NULL} // Final definition must have `signatureLength` == 0.
 };
 
@@ -321,11 +432,13 @@ int jr_viscaDecodeFrame(jr_viscaFrame frame, union jr_viscaMessageParameters *me
             }
             return definitions[i].commandType;
         }
-        // printf("definition %d: sig: ", i);
-        // _jr_viscahex_print(definitions[i].signature, definitions[i].signatureLength);
-        // printf(" sigmask: ");
-        // _jr_viscahex_print(definitions[i].signatureMask, definitions[i].signatureLength);
-        // printf("\n");
+#ifdef VERBOSE_DEF
+         printf("definition %d: sig: ", i);
+         _jr_viscahex_print(definitions[i].signature, definitions[i].signatureLength);
+         printf(" sigmask: ");
+         _jr_viscahex_print(definitions[i].signatureMask, definitions[i].signatureLength);
+         printf("\n");
+#endif
         i++;
     }
 

--- a/jr_visca.h
+++ b/jr_visca.h
@@ -43,10 +43,41 @@
 
 #define JR_VISCA_MESSAGE_PAN_TILT_DRIVE 15
 
+#define JR_VISCA_MESSAGE_CAMERA_NUMBER 16
+
+#define JR_VISCA_MESSAGE_MEMORY 17
+
+#define JR_VISCA_MESSAGE_CLEAR 18
+
+#define JR_VISCA_MESSAGE_PRESET_RECALL_SPEED 19
+
+#define JR_VISCA_MESSAGE_ABSOLUTE_PAN_TILT 20
+
+#define JR_VISCA_MESSAGE_HOME 21
+
+#define JR_VISCA_MESSAGE_RESET 22
+
+#define JR_VISCA_MESSAGE_CANCEL 23
+
+#define JR_VISCA_MESSAGE_CANCEL_REPLY 24
+
 struct jr_viscaPanTiltPositionInqResponseParameters {
     int16_t panPosition;
     int16_t tiltPosition;
 };
+
+// AbsolutePosition 81 01 06 02 VV WW 0Y 0Y 0Y 0Y 0Z 0Z 0Z 0Z FF
+// VV: Pan speed 0x01 (low speed) to 0x18 (high speed)
+// WW: Tilt speed 0x01 (low speed) to 0x14 (high speed)
+// YYYY: Pan Position
+// ZZZZ: Tilt Position
+struct jr_viscaAbsolutePanTiltPositionParameters {
+    int16_t panPosition;
+    int16_t tiltPosition;
+    uint8_t panSpeed;
+    uint8_t tiltSpeed;
+};
+
 
 struct jr_viscaZoomPositionParameters {
     int16_t zoomPosition;
@@ -61,6 +92,25 @@ struct jr_viscaZoomVariableParameters {
     uint8_t zoomSpeed;
 };
 
+
+struct jr_viscaPresetSpeedParameters {
+    // 1-0x18
+    uint8_t presetSpeed;
+};
+
+struct jr_viscaCameraNumberParameters {
+    // 1-7
+    uint8_t cameraNum;
+};
+
+
+struct jr_viscaMemoryParameters {
+    // 1-127
+    uint8_t memory;
+    // 0=reset, 1=set, 2=recall
+    uint8_t mode;
+};
+
 #define JR_VISCA_TILT_DIRECTION_UP 1
 #define JR_VISCA_TILT_DIRECTION_DOWN 2
 #define JR_VISCA_TILT_DIRECTION_STOP 3
@@ -68,6 +118,10 @@ struct jr_viscaZoomVariableParameters {
 #define JR_VISCA_PAN_DIRECTION_LEFT 1
 #define JR_VISCA_PAN_DIRECTION_RIGHT 2
 #define JR_VISCA_PAN_DIRECTION_STOP 3
+
+#define JR_VISCA_MEMORY_MODE_RESET 0
+#define JR_VISCA_MEMORY_MODE_SET 1
+#define JR_VISCA_MEMORY_MODE_RECALL 2
 
 struct jr_viscaPanTiltDriveParameters {
     uint8_t panSpeed; // 1-0x18
@@ -83,6 +137,10 @@ union jr_viscaMessageParameters
     struct jr_viscaZoomVariableParameters zoomVariableParameters;
     struct jr_viscaAckCompletionParameters ackCompletionParameters;
     struct jr_viscaPanTiltDriveParameters panTiltDriveParameters;
+    struct jr_viscaCameraNumberParameters cameraNumberParameters;
+    struct jr_viscaMemoryParameters memoryParameters;
+    struct jr_viscaPresetSpeedParameters presetSpeedParameters;
+    struct jr_viscaAbsolutePanTiltPositionParameters absolutePanTiltPositionParameters;
 };
 
 /**


### PR DESCRIPTION
Memory (reset/set/recall), Home, Reset, PanTiltPosInq, plus Camera Num (technically serial only, though real PTZOptics cameras handle it) and Cancel (from Sony spec; PTZOptics cameras return syntax error although they do interrupt the current recall, so effectively it's a cancel)